### PR TITLE
Fix script variables and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+env/
+__pycache__/
+*.pyc
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ env/bin/pip install pyfzf pyyaml argh
 ```
 
 ```bash
-env/bin/python ye.py test.py
+env/bin/python ye.py test.yaml
 ```

--- a/ye.py
+++ b/ye.py
@@ -2,7 +2,6 @@
 
 import yaml
 import subprocess
-import shlex
 
 from pyfzf.pyfzf import FzfPrompt
 import argh
@@ -14,12 +13,12 @@ def main(cmd_config):
         config = yaml.safe_load(f)
 
     spec = config["spec"]
-    exec = spec["exec"]
+    exec_cfg = spec["exec"]
     args = spec.get("args", [])
 
-    interpreter = exec.get("interpreter", "")
-    command = exec.get("command", "")
-    working_dir = exec.get("workingDir", ".")
+    interpreter = exec_cfg.get("interpreter", "")
+    command = exec_cfg.get("command", "")
+    working_dir = exec_cfg.get("workingDir", ".")
 
     cmd_args = []
 
@@ -59,7 +58,7 @@ def main(cmd_config):
 
     print(f"Running command: {cmd}")
     # Run the command
-    subprocess.run(cmd, cwd=working_dir)
+    subprocess.run(cmd, cwd=working_dir, check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up unused imports in ye.py
- avoid using Python built-in name `exec`
- fail fast when subprocess fails
- correct README example filename
- add a .gitignore for common build artifacts

## Testing
- `ruff check ye.py`
- `python3 -m py_compile ye.py`

------
https://chatgpt.com/codex/tasks/task_e_683fd9d17fd8832085bbecf99e19752a